### PR TITLE
Update cookielaw_tags.py

### DIFF
--- a/cookielaw/templatetags/cookielaw_tags.py
+++ b/cookielaw/templatetags/cookielaw_tags.py
@@ -11,7 +11,7 @@ register = template.Library()
 def cookielaw_banner(context):
     if context['request'].COOKIES.get('cookielaw_accepted', False):
         return ''
-    return render_to_string('cookielaw/banner.html', context)
+    return render_to_string('cookielaw/banner.html', dict(context))
 
 
 @register.inclusion_tag('cookielaw/banner.html')


### PR DESCRIPTION
attending to this change from the django.1.11 version:

https://docs.djangoproject.com/en/2.0/releases/1.11/#django-template-backends-django-template-render-prohibits-non-dict-context

render() phrohibits non dictionary contexts
