### PR TITLE
Update cookielaw_tags.py

### DIFF
--- a/cookielaw/templatetags/cookielaw_tags.py
+++ b/cookielaw/templatetags/cookielaw_tags.py
@@ -11,7 +11,7 @@ register = template.Library()
 def cookielaw_banner(context):
     if context['request'].COOKIES.get('cookielaw_accepted', False):
         return ''
-    return render_to_string('cookielaw/banner.html', context)
+    return render_to_string('cookielaw/banner.html', dict(context))
 
 
 @register.inclusion_tag('cookielaw/banner.html')

--- a/cookielaw/templatetags/cookielaw_tags.py
+++ b/cookielaw/templatetags/cookielaw_tags.py
@@ -11,7 +11,11 @@ register = template.Library()
 def cookielaw_banner(context):
     if context['request'].COOKIES.get('cookielaw_accepted', False):
         return ''
-    return render_to_string('cookielaw/banner.html', dict(context))
+    try:
+        return render_to_string('cookielaw/banner.html', context)
+    except TypeError:
+        # from django 1.11 context needs to be a dictionary
+        return render_to_string('cookielaw/banner.html', context.__dict__)
 
 
 @register.inclusion_tag('cookielaw/banner.html')


### PR DESCRIPTION
fixed cookielaw_tags.py since django 1.11 context needs to be a dictionary into render_to_string  shortcut into cookielaw_banner